### PR TITLE
Fix - Exception data is returned instead of custom error handle data

### DIFF
--- a/flask_restx/api.py
+++ b/flask_restx/api.py
@@ -701,8 +701,6 @@ class Api(object):
         )
         default_data = {}
 
-        result = None
-
         headers = Headers()
 
         for typecheck, handler in six.iteritems(self._own_and_child_error_handlers):
@@ -737,7 +735,7 @@ class Api(object):
         if include_message_in_response:
             default_data["message"] = default_data.get("message", str(e))
 
-        data = getattr(result, "data", default_data)
+        data = getattr(e, "data", default_data)
         fallback_mediatype = None
 
         if code >= HTTPStatus.INTERNAL_SERVER_ERROR:


### PR DESCRIPTION
Fixed issue related to topic 'Exception data is returned instead of custom error handle data'.
Related issues: 
https://github.com/python-restx/flask-restx/issues/33
https://github.com/python-restx/flask-restx/issues/27
https://github.com/python-restx/flask-restx/issues/103
https://github.com/python-restx/flask-restx/issues/102